### PR TITLE
Adjust syft architecture

### DIFF
--- a/assets/scss/mermaid-controls.scss
+++ b/assets/scss/mermaid-controls.scss
@@ -69,7 +69,9 @@ $transition-medium: 0.3s ease;
   box-shadow: $toolbar-shadow-light;
   opacity: 0;
   visibility: hidden;
-  transition: opacity $transition-medium, visibility $transition-medium;
+  transition:
+    opacity $transition-medium,
+    visibility $transition-medium;
   z-index: 10;
   pointer-events: auto;
 
@@ -116,7 +118,7 @@ $transition-medium: 0.3s ease;
 }
 
 // dark mode
-[data-bs-theme="dark"] {
+[data-bs-theme='dark'] {
   .mermaid-controls-toolbar {
     background: $toolbar-bg-dark;
     border-color: $toolbar-border-dark;
@@ -159,7 +161,7 @@ $transition-medium: 0.3s ease;
   }
 }
 
-[data-bs-theme="dark"] .mermaid-fullscreen-backdrop {
+[data-bs-theme='dark'] .mermaid-fullscreen-backdrop {
   background: $backdrop-dark;
 }
 
@@ -177,7 +179,7 @@ $transition-medium: 0.3s ease;
   cursor: default;
 }
 
-[data-bs-theme="dark"] .mermaid-modal-container {
+[data-bs-theme='dark'] .mermaid-modal-container {
   background: #1a1a1a;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
 }
@@ -224,7 +226,7 @@ $transition-medium: 0.3s ease;
   }
 }
 
-[data-bs-theme="dark"] .mermaid-close-btn {
+[data-bs-theme='dark'] .mermaid-close-btn {
   background: $toolbar-bg-dark;
   border-color: $toolbar-border-dark;
   box-shadow: $toolbar-shadow-dark;
@@ -251,8 +253,8 @@ $transition-medium: 0.3s ease;
   border-radius: 0;
 
   svg {
-      width: 100%;
-      height: 100%;
+    width: 100%;
+    height: 100%;
   }
 
   // toolbar always visible in fullscreen

--- a/content/docs/architecture/golang-cli.md
+++ b/content/docs/architecture/golang-cli.md
@@ -1,0 +1,275 @@
++++
+title = "Go CLI patterms"
+description = "All of the common patterns used in our go-based CLIs"
+weight = 10
+url = "docs/architecture/go-cli-patterns"
+categories = ["architecture"]
+tags = ["cli"]
+menu_group = "general"
++++
+
+{{< alert title="TL;DR" color="primary" >}}
+
+We use...
+
+- [Clio](https://github.com/anchore/clio) to orchestrate [cobra](https://github.com/spf13/cobra) and [viper](https://github.com/spf13/viper), covering CLI arg parsing and config file + env var loading.
+- An [event bus](https://github.com/wagoodman/go-partybus) to enabling visibility deep in your execution stack, driving the UI experience.
+- A [logger interface](https://github.com/anchore/go-logger), allowing you to swap out for any concrete logger you'd like (including built in redaction support).
+- [bubbletea](https://github.com/charmbracelet/bubbletea) as the TUI framework with the [bubbly](https://github.com/anchore/bubbly) component library.
+- [binny](https://github.com/anchore/binny) for managing specific versions of developer binary tools for local development.
+- [goreleaser](https://goreleaser.com/) for building and publishing releases.
+- [chronicle](https://github.com/anchore/chronicle) for automatically generating release notes based on github issues and PR titles/labels.
+- [quill](https://github.com/anchore/quill) for signing and notarizing release binaries for Mac.
+
+{{< /alert >}}
+
+This document explains how all of the golang-base Anchore OSS tools are organized, covering the
+package structure, common core architectural concepts, and where key functionality is implemented.
+
+Use this as a reference when trying to familiarize yourself with the overall structure of Syft, Grype, or other applications.
+
+## CLI
+
+The `cmd` package uses the [Clio framework](https://github.com/anchore/clio) (built on top of the [`spf13/cobra`](https://github.com/spf13/cobra) and [`spf13/viper`](https://github.com/spf13/viper)) to manage flag/argument parsing, configuration, and command execution.
+
+All flags, arguments, and config arguments are represented in the application as a struct.
+Each command tends to get it's own struct with all options the command needs to function.
+Common options or sets of options can be defined independently and reused across commands, being composed within each command struct that needs the option.
+
+Select options that represent flags are registered with the `AddFlags` method defined on the command struct (or on each option struct used within the command struct).
+If any additional processing is needed to be done to elements in command structs or option structs before being used in the application then you can define a `PostLoad` method on the struct to mutate the elements you need.
+
+In terms of what is executed when: all processing is done within the selected cobra command's `PreRun` hook, wrapping any potential user-provided hook.
+This means that all of this fits nicely into the existing cobra command lifecycle.
+
+See the [`sign` command](https://github.com/anchore/quill/blob/main/cmd/quill/cli/commands/sign.go) in [Quill](https://github.com/anchore/quill) for a small example of all of this together.
+
+The reason for this approach is to smooth over the rough edges between cobra and viper, which have multiple ways to configure and use functionality, and provide a single way to specify any input into the application.
+Being prescriptive about these approaches has allowed us to take many shared concerns that used to be a lot of boilerplate when creating an application and put it into one framework --[Clio](https://github.com/anchore/clio).
+
+### Execution flow
+
+The following diagrams show the execution of a typical Anchore application at different levels of detail, using the `scan` command in Syft as a representative example:
+
+{{< accordion id="cmdflow" >}}
+{{< accordion-item parent="cmdflow" header="30,000 ft view..." show="true" >}}
+
+```mermaid
+sequenceDiagram
+    actor user as User
+    participant syft as Syft Application
+    participant cmd as Command Handler (Cobra)
+    participant lib as Library
+
+    user->>syft: syft scan alpine:latest
+    syft->>cmd: Execute
+    cmd->>cmd: Initialize & Load Configuration
+    cmd->>lib: Execute Scan Logic
+    lib->>cmd: SBOM
+    cmd-->>user: Display/Write SBOM
+```
+
+{{< /accordion-item >}}
+{{< accordion-item parent="cmdflow" header="20,000 ft view..." >}}
+
+```mermaid
+sequenceDiagram
+    actor user as User
+
+    box rgba(0,0,0,.1) Syft Application
+      participant main as main.go
+      participant cliApp as cli.Application()
+      participant clio as Clio Framework
+    end
+
+    box rgba(0,0,0,.1) Command Handler
+      participant cobra as Command PreRunE
+      participant opts as Command Options
+      participant runE as Command RunE
+    end
+
+    participant lib as Library
+
+    user->>main: syft scan alpine:latest
+
+    Note over main,clio: Syft Application (initialization)
+    main->>cliApp: Create app with ID
+    cliApp->>clio: clio.New(config)
+    clio-->>cliApp: app instance
+
+    Note over cliApp,cobra: Build Command Tree
+    cliApp->>cliApp: commands.Scan(app)
+    cliApp->>clio: app.SetupCommand(&cobra.Command, opts)
+    Note over clio: Bind config sources to options struct
+    clio-->>cliApp: configured scanCmd
+
+    cliApp->>cliApp: commands.Root(app, scanCmd)
+    cliApp->>clio: app.SetupRootCommand(&cobra.Command, opts)
+    clio-->>cliApp: rootCmd with scanCmd attached
+
+    main->>clio: app.Run()
+    clio->>cobra: rootCmd.Execute()
+
+    Note over cobra,runE: Command Handler (execution)
+    cobra->>cobra: Parse args → "scan alpine:latest"
+    cobra->>opts: Load config (files/env/flags)
+    cobra->>opts: opts.PostLoad() validation
+    cobra->>runE: RunE(cmd, args)
+
+    runE->>lib: Execute Scan Logic
+    lib-->>runE: SBOM
+
+    Note over runE: Result Output
+    runE-->>user: SBOM output
+```
+
+{{< /accordion-item >}}
+{{< /accordion >}}
+
+## Package structure
+
+Many of the Anchore OSS tools have the following setup (or very similar):
+
+- **`/cmd/NAME/`** - _CLI application layer_.
+  This is the entry point for the command-line tool and wires up much of the functionality from the public API.
+
+  ```
+  ./cmd/NAME/
+  │   ├── cli/
+  │   │   ├── cli.go          // where all commands are wired up
+  │   │   ├── commands/       // all command implementations
+  │   │   ├── options/        // all command flags and configuration options
+  │   │   └── ui/             // all handlers for events that are shown on the UI
+  │   └── main.go             // entrypoint for the application
+  ...
+  ```
+
+- **`/NAME/`** - _Public library API_.
+  This is how API users interact with the underlying capabilities without coupling to the application configuration, specific presentation on the terminal, or high-level workflows.
+
+### The internalization philosophy
+
+Applications extensively use `internal/` packages at multiple levels to minimize the public API surface area.
+The codebase follows the guiding principle "internalize anything you can" - expose only what library consumers truly need.
+
+Take for example the various `internal` packages within Syft
+
+```
+/internal/               # Project-wide internals (bus, log, etc...)
+/syft/internal/          # Syft library-specific internals (relationships, evidence)
+/cmd/syft/internal/      # CLI-specific internals (options, UI handlers)
+/syft/source/internal/   # Package-specific internals (source resolution details)
+/syft/pkg/cataloger/<ecosystem>/internal/  # Cataloger-specific internals
+```
+
+This multi-level approach allows Syft to expose a minimal, stable public API while keeping implementation details flexible and changeable.
+Go's module system prevents importing `internal/` packages from outside their parent directory, which enforces clean separation of concerns.
+
+## Core facilities
+
+### The bus system
+
+The bus system, under `/internal/bus/` within the target application, is an event publishing mechanism that enables progress reporting and UI updates
+without coupling the library to any specific user interface implementation.
+
+The bus follows a strict one-way communication pattern: the library publishes events but never subscribes to them.
+The intention is that functionality is NOT fulfilled by listening to events on the bus and taking action.
+Only the application layer (CLI) subscribes to events for display.
+This keeps the library completely decoupled from UI concerns.
+
+You can think of the bus as a structured extension of the logger, allowing for publishing not just strings or maps of strings,
+but enabling publishing objects that can yield additional telemetry on-demand, fueling richer interactions.
+
+This enables library consumers to implement any UI they want (terminal UI, web UI, no UI) by subscribing to events and handling them appropriately.
+The library has zero knowledge of how events are used, maintaining a clean separation between business logic and presentation.
+
+The bus is implemented as a singleton with a global publisher that can be set by library consumers:
+
+```go
+var publisher partybus.Publisher
+
+func Set(p partybus.Publisher) {
+    publisher = p
+}
+
+func Publish(e partybus.Event) {
+    if publisher != nil {
+        publisher.Publish(e)
+    }
+}
+```
+
+The library calls `bus.Publish()` throughout cataloging operations. If no publisher is set, events are silently discarded.
+This makes events truly optional.
+
+#### Event streams
+
+Picking the right "level" for events is key. Libraries tend to not assume that events can be read "quickly" off the bus.
+At the same time, to remain lively and useful, we want to be able to have consumers of the bus to get information
+at a rate they choose. A common pattern used is to publish a "start" event (for example, "cataloging started") and
+publish with that event a read-only, thread-safe object that can be polled by the caller to get progress or status-based
+information out.
+
+```mermaid
+sequenceDiagram
+    participant CMD as cmd/<br/>(CLI Layer)
+    participant Bus as internal/bus/<br/>(Event Bus)
+    participant Lib as lib/<br/>(Library Layer)
+    participant Progress as Progress Object
+
+    CMD->>Bus: Subscribe()
+    CMD->>+Lib: PerformOperation()
+    Lib->>Progress: Create progress object
+    Lib->>Bus: Publish(StartEvent, progress)
+    Bus->>CMD: StartEvent
+
+    loop Poll until complete
+        CMD->>Progress: Size(), Current(), Stage(), Error()
+        Progress-->>CMD: status (Error: nil)
+    end
+
+    Lib-->>-CMD: Return result
+    CMD->>Progress: Error()
+    Progress-->>CMD: ErrCompleted
+```
+
+This prevents against the library accidentally being a "firehose" and overwhelming subscribers who are trying to convey
+timely information. When subscribers cannot keep up with the amount of events emitted from the library then the very
+information being displayed tends to get stale and useless anyway. At the same time, the there is a lot of value in
+responding to events instead of polling for all information.
+
+This pattern helps to balance the best of both worlds, getting an event driven system with a consumer-driven update
+cadence.
+
+### The logging system
+
+The logging system, under `/internal/log/` within the target application, provides structured logging throughout Anchore's applications with an injectable [logger interface](https://github.com/anchore/go-logger/blob/main/logger.go).
+This allows library consumers to integrate the application's logging into their own logging infrastructure.
+There is an [adapter for logrus](https://github.com/anchore/go-logger/tree/main/adapter/logrus) to this interface implemented, and we're happy to take additional contributions for other concrete logger adapters.
+
+The logging system is implemented as a singleton with global functions (`log.Info`, `log.Debug`, etc.).
+Library consumers inject their logger by calling the public API function `syft.SetLogger(yourLoggerHere)`.
+
+By default, Syft uses a discard logger (no-op) that silently ignores all log messages.
+This ensures the library produces no output unless a logger is explicitly provided.
+
+All loggers are automatically wrapped with a redaction layer when you call `SetLogger()`.
+The wrapping is applied internally by the logging system, which removes sensitive information (like authentication tokens) from log output.
+This happens transparently within the application CLI, however, API users will need to explicitly register secrets to be redacted.
+
+## Releasing
+
+Each application uses [goreleaser](https://goreleaser.com/) to build and publish releases, as orchestrated by a [`release`](https://github.com/anchore/syft/blob/main/.github/workflows/release.yaml) workflow.
+
+The release workflow can be triggered with `make release` from a local checkout of the repository.
+[Chronicle](https://github.com/anchore/chronicle) is used to automatically generate release notes based on GitHub issues and PR titles/labels,
+using the same information to determine the next version for the release.
+
+With each repo, we tend to publish (but some details may vary slightly between repos):
+
+- a tag with the version (e.g., `v0.50.0`)
+- binaries for Linux, Mac, and Windows, uploaded as GitHub release assets (note, we sign and notarize Mac binaries with [Quill](https://github.com/anchore/quill))
+- Docker images, pushed to Docker Hub and `ghcr.io` registries
+- Update homebrew taps
+
+We ensure the same tool versions are used locally and in CI by using [Binny](https://github.com/anchore/binny), orchestrated with `make` and [`task`](https://taskfile.dev/).

--- a/content/docs/architecture/projects/syft.md
+++ b/content/docs/architecture/projects/syft.md
@@ -9,18 +9,19 @@ menu_group = "projects"
 icon_image = "/images/logos/syft/favicon-48x48.png"
 +++
 
+{{< alert title="Note" color="primary" >}}
+See the [Golang CLI Patterns](/docs/architecture/go-cli-patterns) for **common structures and frameworks** used in Syft and across other Anchore open source projects.
+
+For detailed **API examples**, see the [Syft reponitory on GitHub](https://github.com/anchore/syft/tree/main/examples).
+{{< /alert >}}
+
 ## Code organization
 
 At a high level, this is the package structure of Syft:
 
 ```
-./cmd/syft/
-│   ├── cli/
-│   │   ├── cli.go          // where all commands are wired up
-│   │   ├── commands/       // all command implementations
-│   │   ├── options/        // all command flags and configuration options
-│   │   └── ui/             // all handlers for events that are shown on the UI
-│   └── main.go             // entrypoint for the application
+./cmd/syft/                 // main entrypoint
+│   └── ...
 └── syft/                   // the "core" syft library
     ├── format/             // contains code to encode or decode to and from SBOM formats
     ├── pkg/                // contains code to catalog packages from a source
@@ -28,70 +29,110 @@ At a high level, this is the package structure of Syft:
     └── source/             // contains code to create a source object for some input type (e.g. container image, directory, etc)
 ```
 
-## Core Library Architecture
-
-Syft's core library is implemented in the `syft` package and subpackages. The major packages work together in a pipeline:
+Syft's core library is implemented in the `syft` package and subpackages.
+The major packages work together in a pipeline:
 
 - The `syft/source` package produces a `source.Source` object that can be used to catalog a directory, container, and other source types.
-- The `syft` package contains a single function that can take a `source.Source` object and catalog it, producing an `sbom.SBOM` object.
-- The `syft/format` package contains the ability to encode and decode SBOMs to and from different SBOM formats (such as SPDX and CycloneDX).
+- The `syft` package knows how to take a `source.Source` object and catalog it to produce an `sbom.SBOM` object.
+- The `syft/format` package contains the ability to encode an `sbom.SBOM` object to and from different SBOM formats (such as SPDX and CycloneDX).
 
-This design creates a clear flow: **source → catalog → format**.
+This design creates a clear flow: **source → catalog → format**:
 
-## Command Execution Flow
-
-The `cmd` package at the highest level execution flow wires up [`spf13/cobra`](https://github.com/spf13/cobra) commands for execution in the main application:
-
-```mermaid
-sequenceDiagram
-    participant main as cmd/syft/main
-    participant cli as cli.New()
-    participant root as root.Execute()
-    participant cmd as <command>.Execute()
-
-    main->>+cli:
-
-    Note right of cli: wire ALL CLI commands
-    Note right of cli: add flags for ALL commands
-
-    cli-->>-main:  root command
-
-    main->>+root:
-    root->>+cmd:
-    cmd-->>-root: (error)
-
-    root-->>-main: (error)
-
-    Note right of cmd: Execute SINGLE command from USER
-```
-
-## SBOM Generation Flow
-
-The `packages` command uses the core library to generate an SBOM for the given user input:
+{{< accordion id="sbomflow" >}}
+{{< accordion-item parent="sbomflow" header="30,000 ft view..." show="true" >}}
 
 ```mermaid
 sequenceDiagram
-    participant source as source.New(ubuntu:latest)
-    participant sbom as sbom.SBOM
-    participant catalog as syft.CatalogPackages(src)
-    participant encoder as syft.Encode(sbom, format)
+    actor User
+    participant CLI
+    participant Resolve as Source Resolution
+    participant Catalog as SBOM Creation
+    participant Format as Format Output
 
-    Note right of source: use "ubuntu:latest" as SBOM input
+    User->>CLI: syft scan <target>
+    CLI->>CLI: Parse configuration
 
-    source-->>+sbom: add source to SBOM struct
-    source-->>+catalog: pass src to generate catalog
-    catalog-->-sbom: add cataloging results onto SBOM
-    sbom-->>encoder: pass SBOM and format desired to syft encoder
-    encoder-->>source: return bytes that are the SBOM of the original input
+    CLI->>Resolve: Resolve input (image/dir/file)
+    Note over Resolve: Tries: File→Directory→OCI→Registry→Podman→DockerRetry
+    Resolve-->>CLI: source.Source
 
-    Note right of catalog: cataloger configuration is done based on src
+    CLI->>Catalog: Create SBOM from source
+    Note over Catalog: Task-based cataloging engine
+    Catalog-->>CLI: sbom.SBOM struct
+
+    CLI->>Format: Write to format(s)
+    Note over Format: Parallel: SPDX, CycloneDX, Syft JSON, etc.
+    Format-->>User: SBOM file(s)
+
 ```
 
-For a practical example, see this [gist of using Syft as a library](https://gist.github.com/spiffcs/3027638b7ba904d07e482a712bc00d3d) to generate a SBOM for a docker image.
+{{< /accordion-item >}}
+{{< accordion-item parent="sbomflow" header="20,000 ft view..." >}}
 
-## The `pkg.Package` Object
+Shows the task-based architecture and execution phases.
+Tasks are selected by tags (image/directory/installed) and organized into serial phases, with parallel execution within each phase.
 
-The `pkg.Package` object is a core data structure that represents a software package. Key fields include:
+```mermaid
+sequenceDiagram
+    participant CLI as scan.go
+    participant GetSource as Source Providers
+    participant CreateSBOM as syft.CreateSBOM
+    participant Config as CreateSBOMConfig
+    participant Executor as Task Executor
+    participant Builder as sbomsync.Builder
+    participant Resolver as file.Resolver
+
+    Note over CLI,GetSource: Source Resolution
+    CLI->>GetSource: GetSource(userInput, cfg)
+    GetSource->>GetSource: Try providers until success
+    GetSource-->>CLI: source.Source + file.Resolver
+
+    Note over CLI,Builder: SBOM Creation (task-based architecture)
+    CLI->>CreateSBOM: CreateSBOM(ctx, source, cfg)
+    CreateSBOM->>Config: makeTaskGroups(srcMetadata)
+
+    Note over Config: Task Selection & Organization
+    Config->>Config: Select catalogers by tags<br/>(image/directory/installed)
+    Config->>Config: Organize into execution phases
+    Config-->>CreateSBOM: [][]Task (grouped by phase)
+
+    CreateSBOM->>Builder: Initialize thread-safe builder
+
+    Note over CreateSBOM,Executor: Phase 1: Environment Detection
+    CreateSBOM->>Executor: Execute environment tasks
+    Executor->>Resolver: Read OS release files
+    Executor->>Builder: SetLinuxDistribution()
+
+    Note over CreateSBOM,Executor: Phase 2: Package + File Cataloging
+    CreateSBOM->>Executor: Execute package & file tasks
+    par Parallel Task Execution
+        Executor->>Resolver: Read package manifests
+        Executor->>Builder: AddPackages()
+    and
+        Executor->>Resolver: Read file metadata
+        Executor->>Builder: Add file artifacts
+    end
+
+    Note over CreateSBOM,Executor: Phase 3: Post-Processing
+    CreateSBOM->>Executor: Execute relationship tasks
+    Executor->>Builder: AddRelationships()
+    CreateSBOM->>Executor: Execute cleanup tasks
+
+    CreateSBOM-->>CLI: *sbom.SBOM
+
+    Note over CLI: Format Output
+    CLI->>CLI: Write multi-format output
+```
+
+{{< /accordion-item >}}
+
+{{< /accordion >}}
+
+## The `Package` object
+
+The [`pkg.Package`](https://github.com/anchore/syft/blob/main/syft/pkg/package.go) object is a core data structure that represents a software package.
+
+Key fields include:
 
 - `FoundBy`: the name of the cataloger that discovered this package (e.g. `python-pip-cataloger`).
 - `Locations`: the set of paths and layer IDs that were parsed to discover this package.
@@ -99,9 +140,12 @@ The `pkg.Package` object is a core data structure that represents a software pac
 - `Type`: a high-level categorization of the ecosystem the package resides in. For instance, even if the package is an egg, wheel, or requirements.txt reference, it is still logically a "python" package. Not all package types align with a language (e.g. `rpm`) but it is common.
 - `Metadata`: specialized data for specific location(s) parsed. This should contain as much raw information as seems useful, kept as flat as possible using the raw names and values from the underlying source material.
 
-When `pkg.Package` is serialized, an additional `MetadataType` field is shown to help consumers understand the datashape of the `Metadata` field.
+### Additional package `Metadata`
 
-### MetadataType Naming Conventions
+Packages can have specialized metadata that is specific to the package type and source of information.
+This metadata is stored in the `Metadata` field of the `pkg.Package` struct as an `any` type, allowing for flexibility in the data stored.
+
+When `pkg.Package` is serialized, an additional `MetadataType` field is shown to help consumers understand the datashape of the `Metadata` field.
 
 By convention the `MetadataType` value follows these rules:
 
@@ -125,23 +169,30 @@ When the underlying parsed data represents multiple files, there are two approac
 - Use the primary file to represent all the data. For instance, though the `dpkg-cataloger` looks at multiple files, it's the `status` file that gets represented.
 - Nest each individual file's data under the `Metadata` field. For instance, the `java-archive-cataloger` may find information from `pom.xml`, `pom.properties`, and `MANIFEST.MF`. The metadata is `java-metadata` with each possibility as a nested optional field.
 
-## Cataloger Architecture
+## Package Catalogers
 
 Catalogers are the mechanism by which Syft identifies and constructs packages given a targeted list of files.
 
 For example, a cataloger can ask Syft for all `package-lock.json` files in order to parse and raise up JavaScript packages (see [file globs](https://github.com/anchore/syft/tree/v0.70.0/syft/pkg/cataloger/javascript/cataloger.go#L16-L21) and [file parser functions](https://github.com/anchore/syft/tree/v0.70.0/syft/pkg/cataloger/javascript/cataloger.go#L16-L21) for examples).
 
-### Cataloger Design Principles
+There is a [generic cataloger](https://github.com/anchore/syft/blob/main/syft/pkg/cataloger/generic) implementation that can be leveraged to
+quickly create new catalogers by specifying file globs and parser functions (browse the source code for [syft catalogers](https://github.com/anchore/syft/tree/main/syft/pkg/cataloger) for example usage).
+
+### Design principles
 
 From a high level, catalogers have the following properties:
 
-- **They are independent from one another**. The Java cataloger has no idea of the processes, assumptions, or results of the Python cataloger, for example.
+- **They are independent of one another**. The Java cataloger has no idea of the processes, assumptions,
+  or results of the Python cataloger, for example.
 
-- **They do not know what source is being analyzed**. Are we analyzing a local directory? An image? If so, the squashed representation or all layers? The catalogers do not know the answers to these questions. Only that there is an interface to query for file paths and contents from an underlying "source" being scanned.
+- **They do not know what source is being analyzed**. Are we analyzing a local directory? An image?
+  If so, the squashed representation or all layers? The catalogers do not know the answers to these questions.
+  Only that there is an interface to query for file paths and contents from an underlying "source" being scanned.
 
-- **Packages created by the cataloger should not be mutated after they are created**. There is one exception made for adding CPEs to a package after the cataloging phase, but that will most likely be moved back into the cataloger in the future.
+- **Packages created by the cataloger should not be mutated after they are created**. There is one exception made
+  for adding CPEs to a package after the cataloging phase, but that will most likely be moved back into the cataloger in the future.
 
-### Cataloger Naming Conventions
+### Naming conventions
 
 Cataloger names should be unique and named with these rules in mind:
 
@@ -151,25 +202,34 @@ Cataloger names should be unique and named with these rules in mind:
 - Catalogers for language ecosystems should start with the language name (e.g. `python-`)
 - Distinguish between when the cataloger is searching for evidence of installed packages vs declared packages. For example, there are two different gemspec-based catalogers: `ruby-gemspec-cataloger` and `ruby-installed-gemspec-cataloger`, where the latter requires that the gemspec is found within a `specifications` directory (meaning it was installed, not just at the root of a source repo).
 
-### Generic Cataloger Abstraction
+### File search and selection
 
-`generic.NewCataloger` is an abstraction Syft uses to make writing common components easier (see the [apkdb cataloger](https://github.com/anchore/syft/tree/v0.70.0/syft/pkg/cataloger/apkdb/cataloger.go) for example usage).
+All catalogers are provided an instance of the [`file.Resolver`](https://github.com/anchore/syft/blob/v0.70.0/syft/source/file_resolver.go#L8) to interface with the image and search for files.
+The implementations for these abstractions leverage [`stereoscope`](https://github.com/anchore/stereoscope) to perform searching.
+Here is a rough outline how that works:
 
-It takes the following information as input:
+1. A stereoscope `file.Index` is searched based on the input given (a path, glob, or MIME type). The index is relatively
+   fast to search, but requires results to be filtered down to the files that exist in the specific layer(s) of interest.
+   This is done automatically by the `filetree.Searcher` abstraction. This abstraction will fallback to searching
+   directly against the raw `filetree.FileTree` if the index does not contain the file(s) of interest.
+   Note: the `filetree.Searcher` is used by the `file.Resolver` abstraction.
 
-- A `catalogerName` to identify the cataloger uniquely among all other catalogers.
-- Pairs of file globs as well as parser functions to parse those files. These parser functions return a slice of [`pkg.Package`](https://github.com/anchore/syft/blob/9995950c70e849f9921919faffbfcf46401f71f3/syft/pkg/package.go#L19) as well as a slice of [`artifact.Relationship`](https://github.com/anchore/syft/blob/9995950c70e849f9921919faffbfcf46401f71f3/syft/artifact/relationship.go#L31) to describe how the returned packages are related. See [the apkdb cataloger parser function](https://github.com/anchore/syft/tree/v0.70.0/syft/pkg/cataloger/apkdb/parse_apk_db.go#L22-L102) as an example.
+2. Once the set of files are returned from the `filetree.Searcher` the results are filtered down further to return
+   the most unique file results. For example, you may have requested files by a glob that returns multiple results.
+   These results are filtered down to deduplicate by real files, so if a result contains two references to the same file
+   (one accessed via symlink and one accessed via the real path), then the real path reference is returned and the symlink
+   reference is filtered out. If both were accessed by symlink then the first (by lexical order) is returned.
+   This is done automatically by the `file.Resolver` abstraction.
 
-Catalogers must fulfill the [`pkg.Cataloger` interface](https://github.com/anchore/syft/tree/v0.70.0/syft/pkg/cataloger.go) in order to add packages to the SBOM.
+3. By the time results reach the `pkg.Cataloger` you are guaranteed to have a set of unique files that exist in the
+   layer(s) of interest (relative to what the resolver supports).
 
-For reference, catalogers are [invoked within Syft](https://github.com/anchore/syft/tree/v0.70.0/syft/pkg/cataloger/catalog.go#L41-L100) one after the other, and can be invoked in parallel.
+## CLI and core API
 
-## File Searching with Stereoscope
+The CLI (in the `cmd/syft/` package) and the core library API (in the `syft/` package) are separate layers with a clear boundary.
+Application level concerns always reside with the CLI, while the core library focuses on SBOM generation logic.
+That means that there is an application configuration (e.g. `cmd/syft/cli`) and a separate library configuration, and when the CLI uses
+the library API, it must adapt its configuration to the library's configuration types. In that adapter, the CLI layer
+defers to API-level defaults as much as possible so there is a single source of truth for default behavior.
 
-All catalogers are provided an instance of the [`file.Resolver`](https://github.com/anchore/syft/blob/v0.70.0/syft/source/file_resolver.go#L8) to interface with the image and search for files. The implementations for these abstractions leverage [`stereoscope`](https://github.com/anchore/stereoscope) to perform searching. Here is a rough outline how that works:
-
-1. A stereoscope `file.Index` is searched based on the input given (a path, glob, or MIME type). The index is relatively fast to search, but requires results to be filtered down to the files that exist in the specific layer(s) of interest. This is done automatically by the `filetree.Searcher` abstraction. This abstraction will fallback to searching directly against the raw `filetree.FileTree` if the index does not contain the file(s) of interest. Note: the `filetree.Searcher` is used by the `file.Resolver` abstraction.
-
-2. Once the set of files are returned from the `filetree.Searcher` the results are filtered down further to return the most unique file results. For example, you may have requested files by a glob that returns multiple results. These results are filtered down to deduplicate by real files, so if a result contains two references to the same file (one accessed via symlink and one accessed via the real path), then the real path reference is returned and the symlink reference is filtered out. If both were accessed by symlink then the first (by lexical order) is returned. This is done automatically by the `file.Resolver` abstraction.
-
-3. By the time results reach the `pkg.Cataloger` you are guaranteed to have a set of unique files that exist in the layer(s) of interest (relative to what the resolver supports).
+See the [Syft reponitory on GitHub](https://github.com/anchore/syft/tree/main/examples) for detailed API example usage.


### PR DESCRIPTION
This primarily breaks out common elements for go applications into a separate page and moves the needle on more final syft architecture documentation.