### PR TITLE
fix: make dev on clean checkout

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,6 +70,8 @@ tasks:
 
   dev:
     desc: Start development environment with live reload
+    deps:
+      - install
     cmds:
       - task: hugo:dev
 


### PR DESCRIPTION
`make dev` wasn't working on a clean checkout due to requiring `npm install`, adding this doesn't noticeably change the startup time but will ensure it isn't overlooked when changes are made.