### PR TITLE
fix: site title

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Welcome to Anchore Open Source"
+title = "Welcome"
 linkTitle = "Open Source"
 weight = 30
 +++

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,7 +1,7 @@
 # basic site configuration - these settings control URLs, build output location, and content processing
 baseURL: https://oss.anchore.com/
 languageCode: en-us
-title: ''
+title: 'Anchore Open Source'
 publishDir: public/ # where the generated static site files are written
 timeout: 180s # maximum time for building the site (important for large sites with many pages)
 ignoreLogs:

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -8,18 +8,12 @@
             {{- if $cover }} td-navbar-cover {{- end }}" data-bs-theme="dark">
 <div class="container-fluid flex-column flex-md-row">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
-    {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">
       {{- if ne .Site.Params.ui.navbar_logo false -}}
         {{- /* Use Anchore logo instead of default SVG */ -}}
         <img src="/images/logos/anchore-logo-white.png" alt="Anchore" height="32" style="max-width: 120px;">
       {{ end -}}
     </span>
-    {{- /**/ -}}
-    <span class="navbar-brand__name d-none d-md-inline">
-      {{- .Site.Title -}}
-    </span>
-    {{- /**/ -}}
   </a>
   <div class="td-navbar-nav-scroll ms-md-auto" id="main_navbar">
     <ul class="navbar-nav">


### PR DESCRIPTION
Before this change, the title in the browser is the page title followed by a vertical bar and no other text, e.g. `Syft |`, this sets the title so page titles are followed by a vertical bar and Anchore Open Source, e.g. `Syft | Anchore Open Source`.