### PR TITLE
chore: generate:update passes validate on first pass

### DIFF
--- a/src/generate_reference_syft_json_schema.py
+++ b/src/generate_reference_syft_json_schema.py
@@ -1135,7 +1135,9 @@ def parse_definition(def_name: str, def_schema: dict, all_defs: dict) -> dict[st
             field_desc = ""  # clear description for this special field
         else:
             field_type = expand_type_reference(field_spec, all_defs)
-            field_desc = field_spec.get("description", "")
+            # replace newlines with <br/> to prevent blank lines inside HTML elements,
+            # which would break CommonMark HTML block parsing and make prettier non-idempotent
+            field_desc = field_spec.get("description", "").replace("\n", "<br/>")
 
         is_required = field_name in required_fields
 

--- a/tasks.d/generate.yaml
+++ b/tasks.d/generate.yaml
@@ -37,8 +37,8 @@ tasks:
       - "{{.DATA_SOURCES_CMD}}"
       - "{{.SUPPORTED_OS_CMD}}"
       - "make lint-fix || true"
-      - "uv run pre-commit run end-of-file-fixer --all-files || true"
-      - "uv run pre-commit run trailing-whitespace --all-files || true"
+      - "uv run pre-commit run end-of-file-fixer --all-files --hook-stage push || true"
+      - "uv run pre-commit run trailing-whitespace --all-files --hook-stage push || true"
       - "make validate"
 
   update:
@@ -60,8 +60,8 @@ tasks:
       - "{{.DATA_SOURCES_CMD}} --update"
       - "{{.SUPPORTED_OS_CMD}}"
       - "make lint-fix || true"
-      - "uv run pre-commit run end-of-file-fixer --all-files || true"
-      - "uv run pre-commit run trailing-whitespace --all-files || true"
+      - "uv run pre-commit run end-of-file-fixer --all-files --hook-stage push || true"
+      - "uv run pre-commit run trailing-whitespace --all-files --hook-stage push || true"
       - "make validate"
 
   update-release-notes:


### PR DESCRIPTION
This makes two changes to the generate job:

1. First, it specifies a hook stage when running hooks before generate so that these hooks actually run the correct event and change the files.
2. Second, more controversially perhaps, it changes the generation of JSON within Markdown to use `<br />` for newlines. 

The reason for the second change is that it prettier interprets the newline as the end of the block with the JSON in it, and goes back to linting the markdown, and fails. The other solution I considered was disabling prettier by glob for files that expect to have multiline JSON snippets, but that seems worse. It's possible there's a third way I haven't found.