### PR TITLE
Deignore dot cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,7 @@ strict_equality = true
 root = ["src"]
 
 [tool.pyrefly]
+# Override default project-excludes to remove the **/.[!/.]*/**/* glob,
+# which excludes everything when the repo is cloned under a dot-directory
+# (e.g. .cache/ in CI).
+project-excludes = ["**/node_modules", "**/__pycache__", "**/venv/**/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,3 @@ strict_equality = true
 root = ["src"]
 
 [tool.pyrefly]
-# Override default project-excludes to remove the **/.[!/.]*/**/* glob,
-# which excludes everything when the repo is cloned under a dot-directory
-# (e.g. .cache/ in CI).
-project-excludes = ["**/node_modules", "**/__pycache__", "**/venv/**/*"]

--- a/tasks.d/python.yaml
+++ b/tasks.d/python.yaml
@@ -37,7 +37,7 @@ tasks:
     desc: Run code lint fixers
     cmds:
       - uv run ruff check src tests --fix
-      - uv run pyrefly infer src
+      - uv run pyrefly infer src --disable-project-excludes-heuristics --project-excludes '**/node_modules' '**/__pycache__' '**/venv/**/*'
 
   test:
     desc: Run all tests


### PR DESCRIPTION
otherwise when this is checked out in a path that has a '.whatever' in it, lints don't work.