### PR TITLE
Reduce transient docs generation issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,6 @@ strict_equality = true
 root = ["src"]
 
 [tool.pyrefly]
+# override default project-excludes to remove the hidden directory pattern (**/.[!/.]*/**/*)
+# which incorrectly matches when the checkout path contains .cache (e.g., in CI)
+project-excludes = ["**/node_modules", "**/__pycache__", "**/venv/**/*"]

--- a/src/utils/syft.py
+++ b/src/utils/syft.py
@@ -93,7 +93,12 @@ def run(
             raise
 
     # Docker execution path
-    docker_cmd = ["docker", "run", "--pull", "always", "--rm"]
+    # note: use --pull missing to avoid rate limits (explicit pulls happen at generation start)
+    docker_cmd = ["docker", "run", "--pull", "missing", "--rm"]
+
+    # mount Docker socket so Syft can use host's Docker daemon for image access
+    # this enables shared image cache and auth with the host
+    docker_cmd.extend(["-v", "/var/run/docker.sock:/var/run/docker.sock"])
 
     # always set HOME to avoid path mangling in config output
     # (e.g., ~/go/pkg/mod becomes ~go~pkg~mod without HOME set)

--- a/tasks.d/generate.yaml
+++ b/tasks.d/generate.yaml
@@ -18,8 +18,16 @@ vars:
   SUPPORTED_OS_CMD: "uv run ./src/generate_supported_os_table.py"
 
 tasks:
+  pull-images:
+    desc: Pull all required Docker images
+    cmds:
+      - docker pull anchore/syft:latest
+      - docker pull anchore/grype:latest
+      - docker pull anchore/grant:latest
+
   default:
     desc: Generate all documentation using existing caches
+    deps: [pull-images]
     cmds:
       - "{{.SYFT_CLI_CMD}}"
       - "{{.SYFT_CONFIG_CMD}}"
@@ -43,6 +51,7 @@ tasks:
 
   update:
     desc: Deletes all data caches and generate all documentation
+    deps: [pull-images]
     cmds:
       - "{{.SYFT_CLI_CMD}} --update"
       - "{{.SYFT_CONFIG_CMD}} --update"


### PR DESCRIPTION
Generate has two problems:

1. By pulling tool images in advance and using `--pull missing` we should limit the number of registry operations (especially when tasks are run in parallel). Additionally we now mount the docker socket since there are several syft invocations for generating example output using the same image. This way the first pull can be leveraged for multiple tool invocations. This should help with transient generation issues due to registry auth issues.

2. There is a misconfigured path relative to pyrefly:
```
task: [python:lint-fix] uv run pyrefly infer src
Pattern /home/runner/.cache/oss-release-tracker/anchore/oss-docs/src is matched by `project-excludes` or ignore file.
`project-excludes`: [**/node_modules, **/__pycache__, **/venv/**/*, **/.[!/.]*/**/*], ignore files []
task: Failed to run task "lint-fix": exit status 1
```
This is causing generation to not succeed in CI. The solution is to omit the `.*` ignores from the pyrefly configuration.
