### PR TITLE
Ensure the tool does not update exclude lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ strict_equality = true
 root = ["src"]
 
 [tool.pyrefly]
-# override default project-excludes to remove the hidden directory pattern (**/.[!/.]*/**/*)
-# which incorrectly matches when the checkout path contains .cache (e.g., in CI)
+# disable default excludes heuristics to prevent the hidden directory pattern (**/.[!/.]*/**/*)
+# from being appended - that pattern incorrectly matches when the checkout path contains .cache
+# see: https://pyrefly.org/en/docs/configuration/
+disable-project-excludes-heuristics = true
 project-excludes = ["**/node_modules", "**/__pycache__", "**/venv/**/*"]


### PR DESCRIPTION
With #174 I missed this configuration option: [disable-project-excludes-heuristics](https://pyrefly.org/en/docs/configuration/#disable-project-excludes-heuristics)

> By default, Pyrefly includes several items in your [project-excludes](https://pyrefly.org/en/docs/configuration/#project-excludes) (see project-excludes for the default values). These items are path patterns we've determined rarely have files that should be type checked, but can require a very long time to crawl while enumerating files, or contain third-party code that you likely don't care about errors in. When specifying project-excludes, we always append these defaults to whatever is specified by CLI or in your configuration.

Thus it was still appending `.*` exclude option.