### PR TITLE
Tighten workflow permissions, update dependabot config, and add CodeQL

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -1,3 +1,5 @@
+cooldown: 7d
+
 tools:
   # we want to use a pinned version of binny to manage the toolchain (so binny manages itself!)
   - name: binny

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,32 +2,25 @@ version: 2
 updates:
   # Enable version updates for npm
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+    cooldown:
+      default-days: 7
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "npm"
       include: "scope"
-    cooldown:
-      default-days: 7
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    cooldown:
+      default-days: 7
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/bootstrap"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-    cooldown:
-      default-days: 7

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -40,6 +40,10 @@ jobs:
           - language: javascript-typescript
             build-mode: none
 
+          # Python — doc generation scripts and test utilities in src/ and tests/.
+          - language: python
+            build-mode: none
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,61 @@
+# CodeQL scans for security vulnerabilities and coding errors across all
+# languages in this repo. Results appear in the "Security" tab under
+# "Code scanning alerts" and are enforced by branch protection rules.
+name: "CodeQL"
+
+permissions: {}
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  # Weekly scheduled scan catches newly disclosed vulnerabilities in
+  # existing code, not just changes introduced by PRs.
+  schedule:
+    - cron: '38 11 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to the "Security" tab.
+      security-events: write
+      # Required to fetch internal or private CodeQL packs.
+      packages: read
+      # Only required for workflows in private repositories.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # GitHub Actions workflow linting — no build needed.
+          - language: actions
+            build-mode: none
+
+          # JavaScript/TypeScript — no build needed for CodeQL analysis.
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          # The category tag lets GitHub associate SARIF results with the
+          # correct language when branch protection checks for required
+          # code scanning results.
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -7,14 +7,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   run:
     name: Run E2E tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -7,13 +7,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   validate:
     name: Build and Validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Brings the repo into alignment with org-wide CI hygiene requirements: empty top-level workflow permissions, consolidated and weekly-cadenced dependabot updates, a global binny cooldown, and a new CodeQL scanning workflow.

Changes:
- Set top-level `permissions: {}` on e2e-tests, validate-github-actions, and validations workflows; push `contents: read` down to the job level where it is actually needed
- Consolidate the two github-actions dependabot entries into one using `directories:` (covering `/` and `/.github/actions/*`), and switch both npm and github-actions schedules from daily to weekly
- Add top-level `cooldown: 7d` to `.binny.yaml`
- Add `.github/workflows/codeql.yaml` running CodeQL on `javascript-typescript` and `actions`, triggered on push/PR to main and a weekly schedule

Notes:
- No release.yaml added — this is a docs-only site with no release workflow