### PR TITLE
Fix Grant releases link so that it points to the correct URL

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -102,7 +102,7 @@ url = "/"
                   Get Started
                   <i class="fas fa-arrow-right"></i>
                 </a>
-                <a class="btn btn-secondary" href="https://github.com/anchore/grype/releases"> Releases </a>
+                <a class="btn btn-secondary" href="https://github.com/anchore/grant/releases"> Releases </a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
I've been looking at the OSS docs and this button seems to point to:

https://github.com/anchore/grype/releases

Not:

https://github.com/anchore/grant/releases

<img width="1226" height="602" alt="Screenshot 2026-06-02 at 4 10 26 AM" src="https://github.com/user-attachments/assets/7c358228-db49-4d94-a685-45ee4eccc7fa" />
