### PR TITLE
release pipeline refactor

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,1 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        # anchore/workflows is an internal repository; using @main is acceptable
-        anchore/*: any
+rules: {}


### PR DESCRIPTION
quick zizmor cleanup for oss-docs:

- zizmor.yml trimmed to `rules: {}` (removed the unpinned-uses config)

(docs repo — the rest of the release-pipeline refactor items don't apply here)