### PR TITLE
fix: allow html content

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -5,7 +5,10 @@ inputs:
   node-version:
     description: "node version to install"
     required: true
-    default: "20"
+    # always use the latest LTS release (note: Hugo >= v0.161 runs node helpers
+    # (PostCSS) under Node's permission model (--permission), which requires
+    # Node >= 22.13)
+    default: "lts/*"
   dependencies:
     description: "Download dependencies"
     required: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -13,6 +13,14 @@ ignoreFiles: # patterns for files that should not be processed during site gener
   - data/(grant|grype|syft|sbom)/
 enableGitInfo: true # adds last modified dates from git history to pages
 
+# Hugo >= v0.161 denies text/html content files by default (allowContent: ['! ^text/html$']),
+# which rejects the HTML landing page (content/_index.html). Whitelist exactly the two content
+# media types this site uses instead of the default deny rule.
+security:
+  allowContent:
+    - '^text/markdown$'
+    - '^text/html$'
+
 # theme configuration - imports the Docsy theme which provides layout, styling, and navigation components
 module:
   imports:


### PR DESCRIPTION
This repo uses HTML content but hugo no longer allows this by default. Allow this.