### PR TITLE
Update syft contributing page

### DIFF
--- a/content/docs/contributing/syft.md
+++ b/content/docs/contributing/syft.md
@@ -22,7 +22,7 @@ In order to test and develop in the [Syft repo](https://github.com/anchore/syft)
 Run once after cloning to install development tools:
 
 ```bash
-make bootstrap
+make
 ```
 
 {{< alert color="primary" >}}

--- a/content/docs/contributing/syft.md
+++ b/content/docs/contributing/syft.md
@@ -16,6 +16,7 @@ In order to test and develop in the [Syft repo](https://github.com/anchore/syft)
 - Docker
 - Python (>= 3.9)
 - make
+- skopeo
 
 ### Initial setup
 

--- a/content/docs/contributing/syft.md
+++ b/content/docs/contributing/syft.md
@@ -17,6 +17,7 @@ In order to test and develop in the [Syft repo](https://github.com/anchore/syft)
 - Python (>= 3.9)
 - make
 - skopeo
+- xmllint
 
 ### Initial setup
 

--- a/content/docs/contributing/syft.md
+++ b/content/docs/contributing/syft.md
@@ -12,7 +12,7 @@ icon_image = "/images/logos/syft/favicon-48x48.png"
 
 In order to test and develop in the [Syft repo](https://github.com/anchore/syft) you will need the following dependencies installed:
 
-- Golang
+- Golang (>= 1.26.3)
 - Docker
 - Python (>= 3.9)
 - make


### PR DESCRIPTION
**Remove 'bootstrap' step**
    
  The bootstrap target was removed from [syft/Makefile](https://github.com/anchore/syft/blob/main/Makefile) by syft/7315f83f in 2023.

**Add minimum version for Golang**
    
  This will need to be synchronized with the constraint in https://github.com/anchore/syft/blob/main/go.mod
