### PR TITLE
docs: note PowerShell JSON redirection encoding

### DIFF
--- a/content/docs/guides/vulnerability/json.md
+++ b/content/docs/guides/vulnerability/json.md
@@ -9,6 +9,16 @@ Grype's native JSON output format provides a comprehensive representation of vul
 including detailed information about each vulnerability, how it was matched, and the affected packages.
 This guide explains the structure of the JSON output and how to interpret its contents effectively.
 
+{{< alert title="Windows PowerShell redirection" color="info" >}}
+
+Windows PowerShell may write redirected output with UTF-16LE encoding. If another tool expects UTF-8 JSON, write the report with Grype's `--file` option instead of `>`:
+
+```powershell
+grype <image> -o json --file ./grype-report.json
+```
+
+{{< /alert >}}
+
 ## Data shapes
 
 The JSON output contains a top-level `matches` array. Each match has this structure:


### PR DESCRIPTION
## Summary
- Add a Windows PowerShell note to the Grype JSON guide about redirected output that may be UTF-16LE encoded
- Recommend Grype's `--file` option when downstream tooling expects UTF-8 JSON

Refs anchore/grype#3505

## Verification
- `git diff --check`
- `npx markdownlint-cli2 content/docs/guides/vulnerability/json.md`
- `npm run lint:prettier -- --check content/docs/guides/vulnerability/json.md`
- `npm run build:dev`
