### PR TITLE
docs: add deb-get Syft install method

### DIFF
--- a/content/docs/installation/syft.md
+++ b/content/docs/installation/syft.md
@@ -57,6 +57,14 @@ apk add syft
 
 Thanks to [Michał Polański](https://pkgs.alpinelinux.org/packages?name=&branch=edge&repo=&arch=&maintainer=Micha%C5%82%20Pola%C5%84ski) for maintaining this package.
 
+### deb-get
+
+```bash
+deb-get install syft
+```
+
+- [deb-get Syft package](https://github.com/wimpysworld/deb-get/blob/main/01-main/packages/syft)
+
 ### Homebrew
 
 ```


### PR DESCRIPTION
## Summary
- add deb-get to the Syft community installation methods
- link to the deb-get Syft package definition

Follow-up to anchore/syft#5113.

## Verification
- `git diff --check`
- `npx markdownlint-cli2 content/docs/installation/syft.md`
- `npx prettier --check content/docs/installation/syft.md`