### PR TITLE
docs: correct Grype risk score range

### DIFF
--- a/content/docs/guides/vulnerability/interpreting-results.md
+++ b/content/docs/guides/vulnerability/interpreting-results.md
@@ -45,7 +45,7 @@ The table displays eight standard columns, with an optional ninth column for ann
 - **VULNERABILITY** - The vulnerability identifier (see below)
 - **SEVERITY** - Vulnerability severity rating (Critical, High, Medium, Low, Negligible, Unknown)
 - **EPSS** - [Exploit Prediction Scoring System](https://www.first.org/epss/) score and percentile showing the probability of exploitation
-- **RISK** - Calculated risk score combining CVSS, EPSS, and other severity metrics into a single numeric value (0.0 to 10.0)
+- **RISK** - Calculated risk score combining CVSS, EPSS, and other severity metrics into a single numeric value (0.0 to 100.0)
 - **Annotations** (conditional) - Additional context like KEV (Known Exploited Vulnerability), suppressed status, or distribution version when scanning multi-distro images
 
 Here's what a typical scan looks like:


### PR DESCRIPTION
## Summary
- correct the Grype table-output `RISK` column description to use the documented 0.0 to 100.0 scale
- align the text with the example values shown in the interpreting-results guide

Fixes #185

## Verification
- `git diff --check -- content/docs/guides/vulnerability/interpreting-results.md`
- `npx markdownlint-cli2 content/docs/guides/vulnerability/interpreting-results.md`
- `npx prettier --check content/docs/guides/vulnerability/interpreting-results.md`
