### PR TITLE
Add missing default for javascript.include-dev-dependencies

### DIFF
--- a/data/syft/cli/config/help/output.txt
+++ b/data/syft/cli/config/help/output.txt
@@ -250,7 +250,7 @@ javascript:
   npm-base-url: 'https://registry.npmjs.org'
 
   # include development-scoped dependencies (env: SYFT_JAVASCRIPT_INCLUDE_DEV_DEPENDENCIES)
-  include-dev-dependencies:
+  include-dev-dependencies: false
 
 linux-kernel:
   # whether to catalog linux kernel modules found within lib/modules/** directories (env: SYFT_LINUX_KERNEL_CATALOG_MODULES)

--- a/data/syft/config/output.txt
+++ b/data/syft/config/output.txt
@@ -250,7 +250,7 @@ javascript:
   npm-base-url: 'https://registry.npmjs.org'
 
   # include development-scoped dependencies (env: SYFT_JAVASCRIPT_INCLUDE_DEV_DEPENDENCIES)
-  include-dev-dependencies:
+  include-dev-dependencies: false
 
 linux-kernel:
   # whether to catalog linux kernel modules found within lib/modules/** directories (env: SYFT_LINUX_KERNEL_CATALOG_MODULES)


### PR DESCRIPTION
Hi, 

this PR adds the missing default values for javascript.include-dev-dependencies and makes it clear that it's a boolean.

Regards,
Markus